### PR TITLE
Add cookieKey option supported by hapi-auth-jwt2

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -128,7 +128,8 @@ module.exports = {
             server.auth.strategy('jwt', 'jwt', {
                 key: Authentication.secret(),
                 validate: validate,
-                verifyOptions: {algorithms: ['HS256']}
+                verifyOptions: {algorithms: ['HS256']},
+                cookieKey: COOKIE_NAME
             });
 
             server.auth.strategy("mithril", "mithril", {});


### PR DESCRIPTION
@codingchili,

Thanks for your work on this plugin. 

Adding the "cookieKey" option enables you to configure a cookie name other than "token"

Lauren